### PR TITLE
Fixed an issue where the screen flickered when local videos looped

### DIFF
--- a/wallpaper-play.xcodeproj/project.pbxproj
+++ b/wallpaper-play.xcodeproj/project.pbxproj
@@ -1406,7 +1406,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 2CMV7D36JC;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1421,7 +1421,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.debug.nhiro1109.wallpaper-play";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1440,7 +1440,7 @@
 				CODE_SIGN_ENTITLEMENTS = "wallpaper-play/wallpaper-play.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 2CMV7D36JC;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1455,7 +1455,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nhiro1109.wallpaper-play";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1556,7 +1556,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 2CMV7D36JC;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1573,7 +1573,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -1594,7 +1594,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_ENTITLEMENTS = "Wallpaper Paly SafariEextension/Wallpaper_Paly_SafariEextension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 2CMV7D36JC;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1611,7 +1611,7 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/wallpaper-play/Util/AVPlayerManager.swift
+++ b/wallpaper-play/Util/AVPlayerManager.swift
@@ -23,7 +23,11 @@ protocol AVPlayerManager {
 
 class AVPlayerManagerImpl: AVPlayerManager {
     private var player: AVQueuePlayer?
-    private var endObserver: NSObjectProtocol?
+
+    // Looper: Used when there is only one video being played
+    private var playerLooper: AVPlayerLooper?
+    // An Observer for looping when there are two or more videos playing
+    private var endObserverForLooper2: (any NSObjectProtocol)?
     private var isLooping = false
     
     private var videoContentList: [VideoContent] = []
@@ -33,6 +37,8 @@ class AVPlayerManagerImpl: AVPlayerManager {
     }
 
     func set(_ urls: [URL]) -> AVPlayer {
+        playerLooper?.disableLooping()
+        playerLooper = nil
         player?.pause()
         player?.removeAllItems()
         removeEndObserver()
@@ -65,29 +71,39 @@ class AVPlayerManagerImpl: AVPlayerManager {
     }
     
     func loop() throws {
-        guard player != nil, !videoContentList.isEmpty else {
+        guard let player = player, !videoContentList.isEmpty else {
             throw NSError(domain: "did not set player instance or video contents", code: 1)
         }
-        guard endObserver == nil else { return }
+        guard !isLooping else { return }
+
         isLooping = true
-        endObserver = NotificationCenter.default.addObserver(
-            forName: .AVPlayerItemDidPlayToEndTime,
-            object: nil,
-            queue: nil
-        ) { [weak self] notification in
-            self?.queueDidFinish(notification)
+        if videoContentList.count == 1 {
+            player.removeAllItems()
+            playerLooper = AVPlayerLooper(player: player, templateItem: videoContentList[0].item)
+        } else {
+            endObserverForLooper2 = NotificationCenter.default.addObserver(
+                forName: AVPlayerItem.didPlayToEndTimeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                self?.queueDidFinish(notification)
+            }
         }
     }
     
     func loopOff() throws {
-        guard endObserver != nil, isLooping else {
+        guard isLooping else {
             throw NSError(domain: "did not set looper", code: 2)
         }
         isLooping = false
+        playerLooper?.disableLooping()
+        playerLooper = nil
         removeEndObserver()
     }
     
     func clear() {
+        playerLooper?.disableLooping()
+        playerLooper = nil
         player?.pause()
         player?.removeAllItems()
         removeEndObserver()
@@ -106,8 +122,8 @@ class AVPlayerManagerImpl: AVPlayerManager {
     }
 
     private func removeEndObserver() {
-        guard let endObserver else { return }
-        NotificationCenter.default.removeObserver(endObserver)
-        self.endObserver = nil
+        guard let endObserverForLooper2 else { return }
+        NotificationCenter.default.removeObserver(endObserverForLooper2)
+        self.endObserverForLooper2 = nil
     }
 }


### PR DESCRIPTION
## Summary
Switch looping implementation to AVPlayerLooper when there is a single video item and use a NotificationCenter observer for multi-item looping. Add explicit lifecycle handling for the looper and observers to avoid duplicate observers and leaking loop state.
